### PR TITLE
Fix: Anonymous identity

### DIFF
--- a/android/src/main/java/com/robertsheao/RNZenDeskSupport/RNZenDeskSupportModule.java
+++ b/android/src/main/java/com/robertsheao/RNZenDeskSupport/RNZenDeskSupportModule.java
@@ -56,11 +56,11 @@ public class RNZenDeskSupportModule extends ReactContextBaseJavaModule {
   public void setupIdentity(ReadableMap identity) {
     AnonymousIdentity.Builder builder = new AnonymousIdentity.Builder();
 
-    if (identity.getString("customerEmail") != null) {
+    if (identity.hasKey("customerEmail")) {
       builder.withEmailIdentifier(identity.getString("customerEmail"));
     }
 
-    if (identity.getString("customerName") != null) {
+    if (identity.hasKey("customerName")) {
       builder.withNameIdentifier(identity.getString("customerName"));
     }
 

--- a/android/src/main/java/com/robertsheao/RNZenDeskSupport/RNZenDeskSupportModule.java
+++ b/android/src/main/java/com/robertsheao/RNZenDeskSupport/RNZenDeskSupportModule.java
@@ -55,9 +55,16 @@ public class RNZenDeskSupportModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void setupIdentity(ReadableMap identity) {
     Identity zdIdentity = new AnonymousIdentity.Builder()
-      .withEmailIdentifier(identity.getString("customerEmail"))
-      .withNameIdentifier(identity.getString("customerName"))
-      .build();
+
+    if (identity.getString("customerEmail") != null) {
+      zdIdentity.withEmailIdentifier(identity.getString("customerEmail"));
+    }
+
+    if (identity.getString("customerName") != null) {
+      zdIdentity.withNameIdentifier(identity.getString("customerName"));
+    }
+
+    zdIdentity.build();
 
     ZendeskConfig.INSTANCE.setIdentity(zdIdentity);
   }

--- a/android/src/main/java/com/robertsheao/RNZenDeskSupport/RNZenDeskSupportModule.java
+++ b/android/src/main/java/com/robertsheao/RNZenDeskSupport/RNZenDeskSupportModule.java
@@ -54,19 +54,17 @@ public class RNZenDeskSupportModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void setupIdentity(ReadableMap identity) {
-    Identity zdIdentity = new AnonymousIdentity.Builder()
+    AnonymousIdentity.Builder builder = new AnonymousIdentity.Builder();
 
     if (identity.getString("customerEmail") != null) {
-      zdIdentity.withEmailIdentifier(identity.getString("customerEmail"));
+      builder.withEmailIdentifier(identity.getString("customerEmail"));
     }
 
     if (identity.getString("customerName") != null) {
-      zdIdentity.withNameIdentifier(identity.getString("customerName"));
+      builder.withNameIdentifier(identity.getString("customerName"));
     }
 
-    zdIdentity.build();
-
-    ZendeskConfig.INSTANCE.setIdentity(zdIdentity);
+    ZendeskConfig.INSTANCE.setIdentity(builder.build());
   }
 
   @ReactMethod

--- a/ios/RNZenDeskSupport.m
+++ b/ios/RNZenDeskSupport.m
@@ -30,8 +30,14 @@ RCT_EXPORT_METHOD(initialize:(NSDictionary *)config){
 RCT_EXPORT_METHOD(setupIdentity:(NSDictionary *)identity){
     dispatch_async(dispatch_get_main_queue(), ^{
         ZDKAnonymousIdentity *zdIdentity = [ZDKAnonymousIdentity new];
-        zdIdentity.email = [RCTConvert NSString:identity[@"customerEmail"]];
-        zdIdentity.name = [RCTConvert NSString:identity[@"customerName"]];
+        NSString *email = [RCTConvert NSString:identity[@"customerEmail"];
+        NSString *name = [RCTConvert NSString:identity[@"customerName"];
+        if (email != nil) {
+            zdIdentity.email = email;
+        }
+        if (name != nil) {
+            zdIdentity.name = name;
+        }
         [ZDKConfig instance].userIdentity = zdIdentity;
 
     });

--- a/ios/RNZenDeskSupport.m
+++ b/ios/RNZenDeskSupport.m
@@ -30,8 +30,8 @@ RCT_EXPORT_METHOD(initialize:(NSDictionary *)config){
 RCT_EXPORT_METHOD(setupIdentity:(NSDictionary *)identity){
     dispatch_async(dispatch_get_main_queue(), ^{
         ZDKAnonymousIdentity *zdIdentity = [ZDKAnonymousIdentity new];
-        NSString *email = [RCTConvert NSString:identity[@"customerEmail"];
-        NSString *name = [RCTConvert NSString:identity[@"customerName"];
+        NSString *email = [RCTConvert NSString:identity[@"customerEmail"]];
+        NSString *name = [RCTConvert NSString:identity[@"customerName"]];
         if (email != nil) {
             zdIdentity.email = email;
         }


### PR DESCRIPTION
This allows to omit customerName and customerEmail when settings an identity, so the user can fill it out him/herself.

We don't have this data for all of our users, and setting it to something like "anonymous@anonymous.com" makes the field not editable.