### PR TITLE
Delete unused ZDKNavBarConversationsUITypeNone

### DIFF
--- a/ios/RNZenDeskSupport.m
+++ b/ios/RNZenDeskSupport.m
@@ -49,9 +49,6 @@ RCT_EXPORT_METHOD(showHelpCenterWithOptions:(NSDictionary *)options) {
         UIViewController *vc = [window rootViewController];
         ZDKHelpCenterOverviewContentModel *helpCenterContentModel = [ZDKHelpCenterOverviewContentModel defaultContent];
         helpCenterContentModel.hideContactSupport = [RCTConvert BOOL:options[@"hideContactSupport"]];
-        if (helpCenterContentModel.hideContactSupport) {
-            [ZDKHelpCenter setNavBarConversationsUIType:ZDKNavBarConversationsUITypeNone];
-        }
         vc.modalPresentationStyle = UIModalPresentationFormSheet;
         [ZDKHelpCenter presentHelpCenterOverview:vc withContentModel:helpCenterContentModel];
     });
@@ -65,9 +62,6 @@ RCT_EXPORT_METHOD(showCategoriesWithOptions:(NSArray *)categories options:(NSDic
         helpCenterContentModel.groupType = ZDKHelpCenterOverviewGroupTypeCategory;
         helpCenterContentModel.groupIds = categories;
         helpCenterContentModel.hideContactSupport = [RCTConvert BOOL:options[@"hideContactSupport"]];
-        if (helpCenterContentModel.hideContactSupport) {
-            [ZDKHelpCenter setNavBarConversationsUIType:ZDKNavBarConversationsUITypeNone];
-        }
         vc.modalPresentationStyle = UIModalPresentationFormSheet;
         [ZDKHelpCenter presentHelpCenterOverview:vc withContentModel:helpCenterContentModel];
     });
@@ -81,9 +75,6 @@ RCT_EXPORT_METHOD(showSectionsWithOptions:(NSArray *)sections options:(NSDiction
         helpCenterContentModel.groupType = ZDKHelpCenterOverviewGroupTypeSection;
         helpCenterContentModel.groupIds = sections;
         helpCenterContentModel.hideContactSupport = [RCTConvert BOOL:options[@"hideContactSupport"]];
-        if (helpCenterContentModel.hideContactSupport) {
-            [ZDKHelpCenter setNavBarConversationsUIType:ZDKNavBarConversationsUITypeNone];
-        }
         vc.modalPresentationStyle = UIModalPresentationFormSheet;
         [ZDKHelpCenter presentHelpCenterOverview:vc withContentModel:helpCenterContentModel];
     });
@@ -96,9 +87,6 @@ RCT_EXPORT_METHOD(showLabelsWithOptions:(NSArray *)labels options:(NSDictionary 
         ZDKHelpCenterOverviewContentModel *helpCenterContentModel = [ZDKHelpCenterOverviewContentModel defaultContent];
         helpCenterContentModel.labels = labels;
         helpCenterContentModel.hideContactSupport = [RCTConvert BOOL:options[@"hideContactSupport"]];
-        if (helpCenterContentModel.hideContactSupport) {
-            [ZDKHelpCenter setNavBarConversationsUIType:ZDKNavBarConversationsUITypeNone];
-        }
         vc.modalPresentationStyle = UIModalPresentationFormSheet;
         [ZDKHelpCenter presentHelpCenterOverview:vc withContentModel:helpCenterContentModel];
     });


### PR DESCRIPTION
[This issue](https://github.com/RobertSheaO/react-native-zendesk-support/issues/27) is open since Feb 21. I have faced to this problem many times, and I have tried many solutions that did not work. 
I have just tried to delete 4 if clauses and the errors have gone. In addition, of course everything keep working as expected.

I hope you can give me some feedback about that 👍 